### PR TITLE
Adding an 'auto' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bower install google-analytics-universal-tracker --save
 ```html
 <link rel="import" href="bower_components/google-analytics-universal-tracker/google-analytics-universal-tracker.html">
 <!--...-->
-<google-analytics-universal-tracker code="UA-XXXXXXX-x"></google-analytics-universal-tracker>
+<google-analytics-universal-tracker code="UA-XXXXXXX-x" auto></google-analytics-universal-tracker>
 ```	
 
 If you are using regular anchor links and not push-state links you are ready to go! 

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.2.0"
-    "iron-signals": "PolymerElements/iron-signals#~1.0.2",
+    "iron-signals": "PolymerElements/iron-signals#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -25,8 +25,8 @@
     "tests"
   ],
   "dependencies": {
+    "polymer": "^1.2.0",
     "iron-signals": "PolymerElements/iron-signals#~1.0.2",
-    "polymer": "~1.1.1",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "^1.2.0",
+    "polymer": "Polymer/polymer#^1.2.0"
     "iron-signals": "PolymerElements/iron-signals#~1.0.2",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.2.0"
+    "polymer": "Polymer/polymer#^1.2.0",
     "iron-signals": "PolymerElements/iron-signals#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
   }

--- a/google-analytics-universal-tracker.html
+++ b/google-analytics-universal-tracker.html
@@ -49,6 +49,13 @@ To use Google Analytics user id attribution https://developers.google.com/analyt
                 userId: {
                     type: String,
                     notify: true
+                },
+                /**
+                 * Optinal boolean to send a page view when the element is loaded
+                 */
+                auto: {
+                    type: Boolean,
+                    value: false
                 }
             },
             listeners: {
@@ -57,9 +64,10 @@ To use Google Analytics user id attribution https://developers.google.com/analyt
                 'user-id-changed': 'userIDChanged'
             },
             ready: function() {
-				console.log("setup GS for "+this.code);
                 ga('create', this.code, 'auto');
-                this.trackPage();
+                if (this.auto) {
+                    this.trackPage();
+                }
             },
             trackEvent: function(e) {
                 //Add support for a non-interactin even that does not effect bounce rates - eg things that happen after a timeout
@@ -68,7 +76,7 @@ To use Google Analytics user id attribution https://developers.google.com/analyt
             },
             trackPage: function(e) {
                 //Use set param, this way if we then send a subsequent event on the page it will be correctly associated with the same page
-                if (e != undefined && e.detail.path !== undefined) {
+                if (e !== undefined && e.detail.path !== undefined) {
                     ga('set', 'page', e.detail.path);
                 }
                 ga('send', 'pageview');


### PR DESCRIPTION
Currently, a trackPage is automatically sent in ready callback, whereas there is some case where we don't want this behavior, therefore I propose to add a boolean 'auto' property to handle this case.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/matthewlawson/google-analytics-universal-tracker/2)

<!-- Reviewable:end -->
